### PR TITLE
better support for Atlassian Stash

### DIFF
--- a/lib/flowdock/git.rb
+++ b/lib/flowdock/git.rb
@@ -24,6 +24,7 @@ module Flowdock
     def initialize(options = {})
       @options = options
       @token = options[:token] || config["flowdock.token"] || raise(TokenError.new("Flowdock API token not found"))
+      @repo_name = config["flowdock.repository-name"] || nil
       @commit_url = config["flowdock.commit-url-pattern"] || nil
       @diff_url = config["flowdock.diff-url-pattern"] || nil
       @repo_url = config["flowdock.repository-url"] || nil
@@ -35,6 +36,9 @@ module Flowdock
       req = Net::HTTP::Post.new(uri.path)
 
       payload_hash = data.to_hash
+      if @repo_name
+        payload_hash[:repository][:name] = @repo_name
+      end
       if @repo_url
         payload_hash[:repository][:url] = @repo_url
       end

--- a/lib/flowdock/git.rb
+++ b/lib/flowdock/git.rb
@@ -71,7 +71,7 @@ module Flowdock
     end
 
     def repo
-      @repo ||= Grit::Repo.new(@options[:repo] || Dir.pwd)
+      @repo ||= Grit::Repo.new(@options[:repo] || Dir.pwd, {:is_bare => ENV['STASH_HOOK_CALLBACK'] ? true : false})
     end
 
     private


### PR DESCRIPTION
Atlassian Stash names bare repository directories using an integer ID from Stash's internal representation.  This poses two problems:
- Grit::Repo auto-detects bare repositories by the common use of a ".git" suffix (which is absent in the case of Atlassian Stash)
- The repository name used in the JSON post is meaningless to flow participants

I've addressed these problems in this pull request.  The diff should speak for itself.  The changes should not affect existing users -- except in the rare event that the environment variable STASH_HOOK_CALLBACK is set.  That's an exceedingly unlikely circumstance.
