### PR TITLE
Allow all configuration options to be passed as parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ Note that you can also define token as parameter allowing multiple Flows to be n
     Flowdock::Git.background_post(ref, before, after, :token => "flow-token")
     Flowdock::Git.background_post(ref, before, after, :token => "another-flow")
 
+### Usage as a library
+
+You can use the gem as a library from an application, without the need to set configuration parameters on the Git repository. You can pass the required parameters directly like so:
+
+    Flowdock::Git.post(ref, before, after, :token => "flow-token",
+                        :repo => "/path/to/repo",
+                        :repo_url => "http://example.com/mygitviewer/repo",
+                        :commit_url => "http://example.com/mygitviewer/repo/commit/%s",
+                        :diff_url => "http://example.com/mygitviewer/repo/compare/%s...%s")
+
 ## Example data
 
 The hook uses [GitHub webhook](http://help.github.com/post-receive-hooks/) format.

--- a/lib/flowdock/git.rb
+++ b/lib/flowdock/git.rb
@@ -24,9 +24,9 @@ module Flowdock
     def initialize(options = {})
       @options = options
       @token = options[:token] || config["flowdock.token"] || raise(TokenError.new("Flowdock API token not found"))
-      @commit_url = config["flowdock.commit-url-pattern"] || nil
-      @diff_url = config["flowdock.diff-url-pattern"] || nil
-      @repo_url = config["flowdock.repository-url"] || nil
+      @commit_url = options[:commit_url] || config["flowdock.commit-url-pattern"] || nil
+      @diff_url = options[:diff_url] || config["flowdock.diff-url-pattern"] || nil
+      @repo_url = options[:repo_url] || config["flowdock.repository-url"] || nil
     end
 
     # Send git push notification to Flowdock


### PR DESCRIPTION
This allows the gem to be used as a library from within other applications that might want to integrate with Flowdock.
