### PR TITLE
Get repository path from Grit

### DIFF
--- a/lib/flowdock/git/builder.rb
+++ b/lib/flowdock/git/builder.rb
@@ -40,7 +40,7 @@ module Flowdock
           :commits  => commits,
           :ref_name => @ref.to_s.sub(/\Arefs\/(heads|tags)\//, ''),
           :repository => {
-            :name => File.basename(Dir.pwd).sub(/\.git$/,'')
+            :name => File.basename(@repo.path).sub(/\.git$/,'')
           }
         }).merge(if @before == "0000000000000000000000000000000000000000"
           {:created => true}


### PR DESCRIPTION
The repository may not be in the current working directory, when the gem is used as a library
(e.g. when passed via @options[:repo]).

Would be great to have new gem version released with this!
