### PR TITLE
Support Atlassian Stash repositories by supporting is_bare repos

### DIFF
--- a/lib/flowdock/git.rb
+++ b/lib/flowdock/git.rb
@@ -54,7 +54,10 @@ module Flowdock
     end
 
     def repo
-      @repo ||= Grit::Repo.new(@options[:repo] || Dir.pwd)
+      @repo ||= Grit::Repo.new(
+        @options[:repo] || Dir.pwd,
+        is_bare: @options[:is_bare] || false
+      )
     end
 
     private


### PR DESCRIPTION
Meaning that the repository directory doesn't have to end with .git